### PR TITLE
chore: add support for svelte 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
 			"peerDependencies": {
 				"@sveltejs/kit": "^2.0.0",
 				"joi": "^17.13.3",
-				"svelte": "^4.0.0",
+				"svelte": "^4 || ^5",
 				"zod": "^3.23.8"
 			},
 			"peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	"peerDependencies": {
 		"@sveltejs/kit": "^2.0.0",
 		"joi": "^17.13.3",
-		"svelte": "^4.0.0",
+		"svelte": "^4 || ^5",
 		"zod": "^3.23.8"
 	},
 	"peerDependenciesMeta": {


### PR DESCRIPTION
Svelte 5 is backwards compatible with version 4, and besides Superactions doesn't use any Svelte features that should have changed with the new version.